### PR TITLE
Keep REPL session alive after Enter

### DIFF
--- a/src/dntker/dntker.rs
+++ b/src/dntker/dntker.rs
@@ -283,7 +283,30 @@ impl Dntker {
                     }
                     let statement = self.statement_from_utf8();
                     self.history.push(&statement);
-                    return DntkResult::Fin;
+                    self.write_stdout(&self.prompt.whitespace());
+
+                    if !statement.trim().is_empty() {
+                        let prompt = util::DNTK_PROMPT.to_string();
+                        let separator = " = ";
+                        if let DntkResult::Output(output) =
+                            self.calculate(&prompt, &statement, separator)
+                        {
+                            self.write_stdout(&output);
+                        }
+                    }
+
+                    self.write_stdout("\n");
+                    if util::DNTK_OPT.once {
+                        self.flush();
+                        return DntkResult::Fin;
+                    }
+
+                    self.prompt.reset();
+                    self.buffer.replace("");
+                    self.write_stdout(util::DNTK_PROMPT);
+                    self.flush();
+
+                    return DntkResult::Continue;
                 }
                 FilterResult::Refresh => {
                     self.refresh();


### PR DESCRIPTION
## Summary
- keep the interactive calculator running after pressing Enter by resetting the prompt and buffer instead of exiting immediately
- flush the rendered result, print a newline, and re-display the prompt while preserving `--once` exit semantics

## Testing
- cargo fmt
- cargo test
- cargo clippy -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68f4cec3f4e48331acf55e65e23867b8